### PR TITLE
add variables and omniverse class for utils hints

### DIFF
--- a/codegen/stub_api.py
+++ b/codegen/stub_api.py
@@ -20,7 +20,8 @@ UTILS_MAP = {
     'Export': 'export',
     'Parts': 'parts',
     'Support': 'support',
-    'Adr': 'adr'
+    'Adr': 'adr',
+    'Variables': 'variables'
 }
 
 LIST_OF_IMPORTS = [

--- a/codegen/stub_api.py
+++ b/codegen/stub_api.py
@@ -21,7 +21,8 @@ UTILS_MAP = {
     'Parts': 'parts',
     'Support': 'support',
     'Adr': 'adr',
-    'Variables': 'variables'
+    'Variables': 'variables',
+    'Omniverse': 'omniverse'
 }
 
 LIST_OF_IMPORTS = [


### PR DESCRIPTION
Now that we have the variables utils, we need to fix the hints in the stubs

@randallfrank if the omniverse utils will be ready soon I could hold off this PR so that I can add the right typehints to the omniverse utils as well, provided it will be a util of course